### PR TITLE
Use Cases Layer

### DIFF
--- a/turn-tracker/project/repository/session_repository.py
+++ b/turn-tracker/project/repository/session_repository.py
@@ -1,0 +1,10 @@
+def find_session_by_name(self, name):
+    return name
+
+
+def save(session):
+    return session
+
+
+def update(self, session):
+    return session

--- a/turn-tracker/project/use_cases/game_session.py
+++ b/turn-tracker/project/use_cases/game_session.py
@@ -39,6 +39,13 @@ class GameSession:
         return session
 
     def start(self, name):
+        """
+        Start the board game session.
+        It assumes that all players added previously will not be changed during the game.
+        It defines who is first player in the turn.
+        :return the first player (current player)
+        """
+
         session = self._find_session(name)
         if not session.players:
             raise Exception
@@ -49,6 +56,12 @@ class GameSession:
         return session.turn.current_player()
 
     def finish(self, name):
+        """
+        Finish the board game session.
+        It saves the session current status.
+        :return the session current status
+        """
+
         session = self._find_session(name)
         if not session.started:
             raise Exception

--- a/turn-tracker/project/use_cases/game_session.py
+++ b/turn-tracker/project/use_cases/game_session.py
@@ -1,0 +1,59 @@
+from project.repository import session_repository
+from project.use_cases.turn import Turn
+
+
+class GameSession:
+    """
+    Create the object game session. A game session must have:
+        - name
+        - turns
+        - players
+    A game session may be:
+        - started
+        - finished
+    """
+
+    def __init__(self, name, players: list = [], turn: Turn = None, started=False, finished=False):
+        self.name = name
+        self.players = players
+        self.turn = turn
+        self.started = started
+        self.finished = finished
+
+    def __eq__(self, other):
+        if isinstance(other, GameSession):
+            return self.name == other.name and self.players == other.players \
+                   and self.started == other.started and self.finished == other.finished
+        return False
+
+    @staticmethod
+    def create_session(name):
+        session = GameSession(name)
+        session_repository.save(session)
+        return session
+
+    def add_players(self, name, players: list):
+        session = self._find_session(name)
+        session.players = players
+        session_repository.update(session)
+        return session
+
+    def start(self, name):
+        session = self._find_session(name)
+        if not session.players:
+            raise Exception
+        session.started = True
+        session_repository.update(session)
+        return session
+
+    def finish(self, name):
+        session = self._find_session(name)
+        if not session.started:
+            raise Exception
+        session.finished = True
+        session_repository.update(session)
+        return session
+
+    @staticmethod
+    def _find_session(name):
+        return session_repository.find_session_by_name(name)

--- a/turn-tracker/project/use_cases/game_session.py
+++ b/turn-tracker/project/use_cases/game_session.py
@@ -22,7 +22,7 @@ class GameSession:
 
     def __eq__(self, other):
         if isinstance(other, GameSession):
-            return self.name == other.name and self.players == other.players \
+            return self.name == other.name and self.players == other.players and self.turn == other.turn \
                    and self.started == other.started and self.finished == other.finished
         return False
 
@@ -42,9 +42,11 @@ class GameSession:
         session = self._find_session(name)
         if not session.players:
             raise Exception
+        # start first turn
+        session.turn = Turn(session.players)
         session.started = True
         session_repository.update(session)
-        return session
+        return session.turn.current_player()
 
     def finish(self, name):
         session = self._find_session(name)
@@ -53,6 +55,24 @@ class GameSession:
         session.finished = True
         session_repository.update(session)
         return session
+
+    def current_player(self, name):
+        session = self._find_session(name)
+        if not session.started or session.finished:
+            raise Exception
+        return session.turn.current_player()
+
+    def end_turn(self, name):
+        session = self._find_session(name)
+        if not session.started or session.finished:
+            raise Exception
+        return session.turn.end_turn()
+
+    def skip_turn(self, name):
+        session = self._find_session(name)
+        if not session.started or session.finished:
+            raise Exception
+        session.turn.skip()
 
     @staticmethod
     def _find_session(name):

--- a/turn-tracker/project/use_cases/turn.py
+++ b/turn-tracker/project/use_cases/turn.py
@@ -1,0 +1,54 @@
+import collections
+
+
+class Turn:
+    """
+    Create the object turn. A turn must indicate:
+        - the current player
+        - the next player to play when a player ends its turn
+        - the skipped players
+    """
+    skipped_players = []
+
+    def __init__(self, players):
+        self.players = players
+
+    def __eq__(self, other):
+        if isinstance(other, Turn):
+            return self._compare(self.players, other.players)
+        return False
+
+    @staticmethod
+    def _compare(x, y):
+        return collections.Counter(x) == collections.Counter(y)
+
+    def current_player(self):
+        """
+        :return the current player
+        """
+        return self.players[0]
+
+    def end_turn(self):
+        """
+        End the turn of the current player.
+        Validates if the following players can play (have not skipped his/hers turn).
+        :return the following player
+        """
+        player_to_skip = next((i for i, p in enumerate(self.skipped_players) if p == self.players[1]), False)
+        if player_to_skip is not False:
+            self.skipped_players.pop(player_to_skip)
+            self._get_next_player()
+            return self.end_turn()
+        return self._get_next_player()
+
+    def _get_next_player(self):
+        player = self.players.pop(0)
+        self.players.append(player)
+        return self.players[0]
+
+    def skip(self):
+        """
+        Set that the player will not play in the upcoming turn.
+        So it will pass the turn ti the next player.
+        """
+        self.skipped_players.append(self.players[0])

--- a/turn-tracker/tests/use_cases/test_game_session.py
+++ b/turn-tracker/tests/use_cases/test_game_session.py
@@ -1,0 +1,97 @@
+import unittest
+from unittest.mock import patch
+
+from project.domain.player import Player
+from project.use_cases.game_session import GameSession
+
+
+class GameSessionTest(unittest.TestCase):
+    players = [
+        Player(
+            name="John Doe",
+            date_of_birth="1990-04-03",
+            is_associate=True,
+            position=1,
+            is_host=True
+        ),
+        Player(
+            name="Katherine Ryan",
+            date_of_birth="1983-06-30",
+            is_associate=True,
+            position=2,
+            is_host=False
+        ),
+        Player(
+            name="Iliza Shlesinger",
+            date_of_birth="1983-02-22",
+            is_associate=False,
+            position=3,
+            is_host=False
+        ),
+        Player(
+            name="Tina Fey",
+            date_of_birth="1970-05-18",
+            is_associate=False,
+            position=4,
+            is_host=False
+        )]
+
+    session = GameSession(name="A comedianne walks into a bar...")
+
+    session_with_players = GameSession(name="A comedianne walks into a bar...",
+                                       players=players)
+
+    session_started = GameSession(name="A comedianne walks into a bar...",
+                                  players=players,
+                                  started=True)
+
+    @patch("project.repository.session_repository.save")
+    def test_create_session(self, mock_save):
+        result = self.session.create_session(self.session.name)
+
+        mock_save.assert_called_once()
+        self.assertEqual(result.name, self.session.name)
+
+    @patch("project.repository.session_repository.update")
+    @patch("project.repository.session_repository.find_session_by_name", return_value=session)
+    def test_add_players_to_session(self, mock_find_session_by_name, mock_update):
+        result = self.session.add_players(self.session.name, self.players)
+
+        mock_find_session_by_name.assert_called_once_with(self.session.name)
+        mock_update.assert_called_once()
+        self.assertEqual(result.name, self.session.name)
+        self.assertEqual(result.players, self.players)
+
+    @patch("project.repository.session_repository.update")
+    @patch("project.repository.session_repository.find_session_by_name", return_value=session_with_players)
+    def test_start_session(self, mock_find_session_by_name, mock_update):
+        result = self.session_with_players.start(self.session_with_players.name)
+
+        mock_find_session_by_name.assert_called_once_with(self.session_with_players.name)
+        mock_update.assert_called_once()
+        self.assertEqual(result.name, self.session_with_players.name)
+        self.assertEqual(result.players, self.players)
+        self.assertTrue(result.started)
+
+    @patch("project.repository.session_repository.find_session_by_name", return_value=session)
+    def test_raise_BusinessException_when_try_start_session_without_players(self, mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session.start(self.session.name)
+            mock_find_session_by_name.assert_called_once_with(self.session.name)
+
+    @patch("project.repository.session_repository.update")
+    @patch("project.repository.session_repository.find_session_by_name", return_value=session_started)
+    def test_finish_session(self, mock_find_session_by_name, mock_update):
+        result = self.session_started.finish(self.session_started.name)
+
+        mock_find_session_by_name.assert_called_once_with(self.session_started.name)
+        mock_update.assert_called_once()
+        self.assertEqual(result.name, self.session_started.name)
+        self.assertEqual(result.players, self.players)
+        self.assertTrue(result.finished)
+
+    @patch("project.repository.session_repository.find_session_by_name", return_value=session)
+    def test_raise_BusinessException_when_try_finish_not_started_session(self, mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session.finish(self.session.name)
+            mock_find_session_by_name.assert_called_once_with(self.session.name)

--- a/turn-tracker/tests/use_cases/test_game_session.py
+++ b/turn-tracker/tests/use_cases/test_game_session.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 from project.domain.player import Player
 from project.use_cases.game_session import GameSession
+from project.use_cases.turn import Turn
 
 
 class GameSessionTest(unittest.TestCase):
@@ -36,62 +37,164 @@ class GameSessionTest(unittest.TestCase):
             is_host=False
         )]
 
-    session = GameSession(name="A comedianne walks into a bar...")
+    turn = Turn(players)
 
-    session_with_players = GameSession(name="A comedianne walks into a bar...",
-                                       players=players)
+    session_name = "A comedianne walks into a bar..."
 
-    session_started = GameSession(name="A comedianne walks into a bar...",
-                                  players=players,
-                                  started=True)
+    session = GameSession(name=session_name)
+
+    session_with_players = GameSession(name=session_name, players=players)
+
+    session_started = GameSession(name=session_name, players=players, turn=turn, started=True)
+
+    session_finished = GameSession(name=session_name, players=players, turn=turn, started=True, finished=True)
 
     @patch("project.repository.session_repository.save")
     def test_create_session(self, mock_save):
-        result = self.session.create_session(self.session.name)
+        result = GameSession.create_session(self.session_name)
 
         mock_save.assert_called_once()
-        self.assertEqual(result.name, self.session.name)
+        self.assertEqual(result.name, self.session_name)
 
     @patch("project.repository.session_repository.update")
-    @patch("project.repository.session_repository.find_session_by_name", return_value=session)
+    @patch("project.repository.session_repository.find_session_by_name", return_value=GameSession(name=session_name))
     def test_add_players_to_session(self, mock_find_session_by_name, mock_update):
-        result = self.session.add_players(self.session.name, self.players)
+        result = self.session.add_players(self.session_name, self.players)
 
-        mock_find_session_by_name.assert_called_once_with(self.session.name)
+        mock_find_session_by_name.assert_called_once_with(self.session_name)
         mock_update.assert_called_once()
-        self.assertEqual(result.name, self.session.name)
+        self.assertEqual(result.name, self.session_name)
         self.assertEqual(result.players, self.players)
 
+    @patch("project.use_cases.turn.Turn.current_player", return_value=Player(name="John Doe",
+                                                                             date_of_birth="1990-04-03",
+                                                                             is_associate=True,
+                                                                             position=1, is_host=True))
     @patch("project.repository.session_repository.update")
-    @patch("project.repository.session_repository.find_session_by_name", return_value=session_with_players)
-    def test_start_session(self, mock_find_session_by_name, mock_update):
-        result = self.session_with_players.start(self.session_with_players.name)
+    @patch("project.repository.session_repository.find_session_by_name", return_value=GameSession(name=session_name,
+                                                                                                  players=players))
+    def test_start_session(self, mock_find_session_by_name, mock_update, mock_get_current_player):
+        result = self.session_with_players.start(self.session_name)
 
-        mock_find_session_by_name.assert_called_once_with(self.session_with_players.name)
+        mock_find_session_by_name.assert_called_once_with(self.session_name)
         mock_update.assert_called_once()
-        self.assertEqual(result.name, self.session_with_players.name)
-        self.assertEqual(result.players, self.players)
-        self.assertTrue(result.started)
+        mock_get_current_player.assert_called_once()
+        self.assertEqual(result, Player(name="John Doe",
+                                        date_of_birth="1990-04-03",
+                                        is_associate=True,
+                                        position=1, is_host=True))
 
-    @patch("project.repository.session_repository.find_session_by_name", return_value=session)
+    @patch("project.repository.session_repository.find_session_by_name", return_value=GameSession(name=session_name))
     def test_raise_BusinessException_when_try_start_session_without_players(self, mock_find_session_by_name):
         with self.assertRaises(Exception):
-            self.session.start(self.session.name)
-            mock_find_session_by_name.assert_called_once_with(self.session.name)
+            self.session.start(self.session_name)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)
 
     @patch("project.repository.session_repository.update")
-    @patch("project.repository.session_repository.find_session_by_name", return_value=session_started)
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players, turn=turn, started=True))
     def test_finish_session(self, mock_find_session_by_name, mock_update):
-        result = self.session_started.finish(self.session_started.name)
+        result = self.session_started.finish(self.session_name)
 
-        mock_find_session_by_name.assert_called_once_with(self.session_started.name)
+        mock_find_session_by_name.assert_called_once_with(self.session_name)
         mock_update.assert_called_once()
-        self.assertEqual(result.name, self.session_started.name)
+        self.assertEqual(result.name, self.session_name)
         self.assertEqual(result.players, self.players)
         self.assertTrue(result.finished)
 
-    @patch("project.repository.session_repository.find_session_by_name", return_value=session)
+    @patch("project.repository.session_repository.find_session_by_name", return_value=GameSession(name=session_name))
     def test_raise_BusinessException_when_try_finish_not_started_session(self, mock_find_session_by_name):
         with self.assertRaises(Exception):
-            self.session.finish(self.session.name)
-            mock_find_session_by_name.assert_called_once_with(self.session.name)
+            self.session.finish(self.session_name)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)
+
+    @patch("project.use_cases.turn.Turn.current_player", return_value=Player(name="John Doe",
+                                                                             date_of_birth="1990-04-03",
+                                                                             is_associate=True,
+                                                                             position=1, is_host=True))
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players, turn=turn, started=True))
+    def test_get_current_player(self, mock_find_session_by_name, mock_get_current_player):
+        result = self.session_started.current_player(self.session_name)
+
+        mock_find_session_by_name.assert_called_once_with(self.session_name)
+        mock_get_current_player.assert_called_once()
+        self.assertEqual(result, Player(name="John Doe",
+                                             date_of_birth="1990-04-03",
+                                             is_associate=True,
+                                             position=1, is_host=True))
+
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players))
+    def test_raise_BusinessExcpetion_when_try_get_current_player_before_started_session(self,
+                                                                                        mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session_with_players.current_player(self.session_with_players)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)
+
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players, turn=turn, started=True, finished=True))
+    def test_raise_BusinessExcpetion_when_try_get_current_player_after_finished_session(self,
+                                                                                        mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session_with_players.current_player(self.session_finished)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)
+
+    @patch("project.use_cases.turn.Turn.end_turn", return_value=Player(name="Katherine Ryan",
+                                                                       date_of_birth="1983-06-30",
+                                                                       is_associate=True,
+                                                                       position=2,
+                                                                       is_host=False))
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players, turn=turn, started=True))
+    def test_end_turn_and_get_next_player(self, mock_find_session_by_name, mock_end_turn):
+        result = self.session_started.end_turn(self.session_name)
+
+        mock_find_session_by_name.assert_called_once_with(self.session_name)
+        mock_end_turn.assert_called_once()
+        self.assertEqual(result, Player(name="Katherine Ryan",
+                                        date_of_birth="1983-06-30",
+                                        is_associate=True,
+                                        position=2,
+                                        is_host=False))
+
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players))
+    def test_raise_BusinessExcpetion_when_try_get_next_player_before_started_session(self,
+                                                                                     mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session_with_players.end_turn(self.session_with_players)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)
+
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players, turn=turn, started=True, finished=True))
+    def test_raise_BusinessExcpetion_when_try_get_next_player_after_finished_session(self,
+                                                                                     mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session_with_players.end_turn(self.session_finished)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)
+
+    @patch("project.use_cases.turn.Turn.skip", return_value=turn)
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players, turn=turn, started=True))
+    def test_skip_turn(self, mock_find_session_by_name, mock_skip_turn):
+        self.session_started.skip_turn(self.session_name)
+
+        mock_find_session_by_name.assert_called_once_with(self.session_name)
+        mock_skip_turn.assert_called_once()
+
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players))
+    def test_raise_BusinessExcpetion_when_try_skip_turn_before_started_session(self,
+                                                                               mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session_with_players.skip_turn(self.session_name)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)
+
+    @patch("project.repository.session_repository.find_session_by_name",
+           return_value=GameSession(name=session_name, players=players, turn=turn, started=True, finished=True))
+    def test_raise_BusinessExcpetion_when_try_skip_turn_after_finished_session(self,
+                                                                               mock_find_session_by_name):
+        with self.assertRaises(Exception):
+            self.session_with_players.skip_turn(self.session_name)
+            mock_find_session_by_name.assert_called_once_with(self.session_name)

--- a/turn-tracker/tests/use_cases/test_turn.py
+++ b/turn-tracker/tests/use_cases/test_turn.py
@@ -1,0 +1,129 @@
+import unittest
+
+from project.domain.player import Player
+from project.use_cases.turn import Turn
+
+
+class TurnTest(unittest.TestCase):
+    players = [
+        Player(
+            name="John Doe",
+            date_of_birth="1990-04-03",
+            is_associate=True,
+            position=1,
+            is_host=True
+        ),
+        Player(
+            name="Katherine Ryan",
+            date_of_birth="1983-06-30",
+            is_associate=True,
+            position=2,
+            is_host=False
+        ),
+        Player(
+            name="Iliza Shlesinger",
+            date_of_birth="1983-02-22",
+            is_associate=False,
+            position=3,
+            is_host=False
+        ),
+        Player(
+            name="Tina Fey",
+            date_of_birth="1970-05-18",
+            is_associate=False,
+            position=4,
+            is_host=False
+        )]
+
+    turn = Turn(players=players)
+
+    def test_turn_init(self):
+        turn = Turn(players=self.players)
+
+        self.assertEqual(turn.players[0], self.players[0])
+        self.assertEqual(turn.players[1], self.players[1])
+        self.assertEqual(turn.players[2], self.players[2])
+        self.assertEqual(turn.players[3], self.players[3])
+
+    def test_current_player(self):
+        result = self.turn.current_player()
+        self.assertEqual(result, self.players[0])
+
+    def test_end_turn(self):
+        result = self.turn.end_turn()
+        self.assertEqual(result, Player(name="Katherine Ryan", date_of_birth="1983-06-30",
+                                        is_associate=True, position=2, is_host=False))
+        self.assertEqual(self.turn.players, [Player(name="Katherine Ryan", date_of_birth="1983-06-30",
+                                                    is_associate=True, position=2, is_host=False),
+                                             Player(name="Iliza Shlesinger", date_of_birth="1983-02-22",
+                                                    is_associate=False, position=3, is_host=False),
+                                             Player(name="Tina Fey", date_of_birth="1970-05-18",
+                                                    is_associate=False, position=4, is_host=False),
+                                             Player(name="John Doe", date_of_birth="1990-04-03",
+                                                    is_associate=True, position=1, is_host=True)])
+
+    def test_a_player_skip_turns(self):
+        players = [Player(name="Sarah Silverman", date_of_birth="1970-12-01", is_associate=False,
+                          position=1, is_host=False),
+                   Player(name="Gabriel Iglesias", date_of_birth="1976-07-15", is_associate=False,
+                          position=2, is_host=True)]
+
+        turn = Turn(players)
+
+        # sarah turns
+        turn.skip()
+        turn.end_turn()
+
+        # gabriel turns
+        result = turn.end_turn()
+
+        self.assertEqual(result, Player(name="Gabriel Iglesias", date_of_birth="1976-07-15", is_associate=False,
+                                        position=2, is_host=True))
+        self.assertEqual(turn.players, players)
+        self.assertFalse(turn.skipped_players)
+
+    def test_all_players_skip_turns(self):
+        players = [Player(name="Sarah Silverman", date_of_birth="1970-12-01", is_associate=False,
+                          position=1, is_host=False),
+                   Player(name="Gabriel Iglesias", date_of_birth="1976-07-15", is_associate=False,
+                          position=2, is_host=True)]
+
+        turn = Turn(players)
+
+        # sarah turns
+        turn.skip()
+        turn.end_turn()
+
+        # gabriel turns
+        turn.skip()
+        result = turn.end_turn()
+
+        self.assertEqual(result, Player(name="Sarah Silverman", date_of_birth="1970-12-01", is_associate=False,
+                                        position=1, is_host=False))
+        self.assertEqual(turn.players, players)
+        self.assertFalse(turn.skipped_players)
+
+    def test_player_skip_multiple_turns(self):
+        players = [Player(name="Sarah Silverman", date_of_birth="1970-12-01", is_associate=False,
+                          position=1, is_host=False),
+                   Player(name="Gabriel Iglesias", date_of_birth="1976-07-15", is_associate=False,
+                          position=2, is_host=True)]
+
+        turn = Turn(players)
+
+        # sarah turns
+        turn.skip()
+        turn.skip()
+        turn.skip()
+        turn.end_turn()
+
+        # gabriel turn
+        result = turn.end_turn()
+
+        self.assertEqual(result, Player(name="Gabriel Iglesias", date_of_birth="1976-07-15", is_associate=False,
+                                        position=2, is_host=True))
+        self.assertEqual(turn.players, players)
+        self.assertEqual(turn.skipped_players, [Player(name="Sarah Silverman", date_of_birth="1970-12-01",
+                                                       is_associate=False, position=1, is_host=False),
+                                                Player(name="Sarah Silverman", date_of_birth="1970-12-01",
+                                                       is_associate=False, position=1, is_host=False)])


### PR DESCRIPTION
# The Use Cases Layer
![Group 1(1)](https://user-images.githubusercontent.com/22627896/133004517-d3125e73-baae-4c25-8dc0-b59fb28c1f88.png)

The use cases layer is the place where all the business rules are located. In this example it was implemented some of the following [Board Game Association functional requirements](https://github.com/liliancavalet/flask-react-experiment/blob/main/documentation/requirements.md):
>  It wants to have all players registered, even the non-associates. It only requires the name and age of a player.
    It wants to keep track of the participants of each board game played, and who is the host. The host must be an associate of the Board Game Association.
    It wants to keep track of who is the next player.
    It wants to skip a turn of a player when required.
    It wants to keep the record of the session players' order.

All these requirements can be summarized in a use case to orchestrate the whole game session.  The main use case, here defined as `game_session`, handles the players' enrollment, the sessions start, and the session end. Inside this use case, there is another one (`turn`) to handle who is the next player and the board game rules. They are built to define how the data flows from the external layers to the entities and vice-versa. So they are expected to change as the application grows.

As mentioned, this layer can be modified, but we need to be clear that the modifications expected are strictly related to the business needs. No changes to the database, the UI, or any of the common frameworks should impact this layer. Because of this, it must be isolated from outer levels, which means it needs an interface between layers. To achieve this, especially when testing, we can use the [mock strategy from the Test Double](https://martinfowler.com/bliki/TestDouble.html).

## References used to create this pull request

:symbols: Python [type function params](https://stackoverflow.com/a/21384492)
:test_tube: TDD with [unittest](https://docs.python.org/3/library/unittest.html)
:adhesive_bandage: Mocking code that accesses an interface (in our case the `repository`) with [patch](https://docs.python.org/3/library/unittest.mock.html#unittest.mock.patch)
:penguin: [Git and the interactive patch add](https://dev.to/etcwilde/git-and-the-interactive-patch-add)
:bookmark_tabs: [Chapter 3: A basic example, _Clean Architectures in Python_](https://www.thedigitalcatbooks.com/pycabook-chapter-03/)
:bookmark_tabs: [The Clean Architecture](https://blog.cleancoder.com/uncle-bob/2012/08/13/the-clean-architecture.html)

